### PR TITLE
Fix #2: sysv runlevels empty

### DIFF
--- a/openrc/postinst.patch
+++ b/openrc/postinst.patch
@@ -1,15 +1,14 @@
 --- postinst	2024-07-23 15:51:35.000000000 +0100
 +++ postinst-openrc	2024-08-18 13:24:04.961013819 +0100
-@@ -3,9 +3,9 @@
- 
+@@ -3,9 +3,8 @@
+
  chmod u+s "/usr/bin/mullvad-exclude"
- 
+
 -systemctl enable "/usr/lib/systemd/system/mullvad-daemon.service"
 -systemctl start mullvad-daemon.service || echo "Failed to start mullvad-daemon.service"
 -systemctl enable "/usr/lib/systemd/system/mullvad-early-boot-blocking.service"
 +rc-update add mullvad-daemon default
 +service mullvad-daemon start
-+rc-update add mullvad-early-boot-blocking default
- 
+
  # return 0 if version $1 is greater than or equal to $2
  function version_is_ge {

--- a/openrc/preinst.patch
+++ b/openrc/preinst.patch
@@ -1,9 +1,9 @@
 --- preinst	2024-07-23 15:51:35.000000000 +0100
 +++ preinst-openrc	2024-08-18 13:25:19.066673722 +0100
-@@ -1,15 +1,13 @@
+@@ -1,15 +1,12 @@
  #!/usr/bin/env bash
  set -eu
- 
+
 -if which systemctl &> /dev/null && systemctl is-system-running | grep -vq offline &> /dev/null; then
 -    if systemctl status mullvad-daemon &> /dev/null; then
 -        /opt/Mullvad\ VPN/resources/mullvad-setup prepare-restart || true
@@ -17,9 +17,8 @@
 +    /opt/Mullvad\ VPN/resources/mullvad-setup prepare-restart || true
 +    service mullvad-daemon stop
 +    rc-update del mullvad-daemon default
-+    rc-update del mullvad-early-boot-blocking default || true
 +    cp /var/log/mullvad-vpn/daemon.log /var/log/mullvad-vpn/old-install-daemon.log \
 +        || echo "Failed to copy old daemon log"
  fi
- 
+
  # This can be removed when 2022.4 is unsupported. That version is the last version where

--- a/openrc/prerm.patch
+++ b/openrc/prerm.patch
@@ -1,8 +1,8 @@
 --- prerm	2022-10-14 11:36:49.000000000 +0100
-+++ /home/tfm/mullvad-repack/prerm	2022-11-13 11:34:53.472140703 +0000
-@@ -21,10 +21,10 @@
++++ prerm-openrc	2022-11-13 11:34:53.472140703 +0000
+@@ -21,10 +21,9 @@
  fi
- 
+
  # the user might've disabled or stopped the service themselves already
 -systemctl stop mullvad-daemon.service || true
 -systemctl disable mullvad-daemon.service || true
@@ -10,8 +10,7 @@
 -systemctl disable mullvad-early-boot-blocking.service || true
 +service mullvad-daemon stop || true
 +rc-update del mullvad-daemon default || true
-+service mullvad-early-boot-blocking stop || true
-+rc-update del mullvad-early-boot-blocking default || true
- 
++rm -f /etc/cron.d/mullvad-early-boot-blocking
+
  /opt/Mullvad\ VPN/resources/mullvad-setup reset-firewall || echo "Failed to reset firewall"
  /opt/Mullvad\ VPN/resources/mullvad-setup remove-device || echo "Failed to remove device from account"

--- a/repack.sh
+++ b/repack.sh
@@ -44,11 +44,10 @@ fi
 mkdir -p repack/etc/cron.d
 cp mullvad-early-boot-blocking repack/etc/cron.d
 chmod go-w repack/etc/cron.d/mullvad-early-boot-blocking
-sudo chown root: repack/etc/cron.d/mullvad-early-boot-blocking
 
 # Patch the packaging scripts.
 patch -l repack/DEBIAN/preinst < "${init_system}/preinst.patch"
 patch -l repack/DEBIAN/postinst < "${init_system}/postinst.patch"
 patch -l repack/DEBIAN/prerm < "${init_system}/prerm.patch"
 
-dpkg-deb -b repack "${file%".deb"}-repack.deb"
+dpkg-deb --root-owner-group -b repack "${file%".deb"}-repack.deb"

--- a/runit/postinst.patch
+++ b/runit/postinst.patch
@@ -1,18 +1,18 @@
 --- postinst	2024-07-23 15:51:35.000000000 +0100
-+++ postinst-openrc	2024-08-18 13:24:04.961013819 +0100
++++ postinst-runit	2024-08-18 13:24:04.961013819 +0100
 @@ -3,9 +3,12 @@
- 
+
  chmod u+s "/usr/bin/mullvad-exclude"
- 
+
 -systemctl enable "/usr/lib/systemd/system/mullvad-daemon.service"
 -systemctl start mullvad-daemon.service || echo "Failed to start mullvad-daemon.service"
 -systemctl enable "/usr/lib/systemd/system/mullvad-early-boot-blocking.service"
 +ln -sf /etc/sv/mullvad-daemon /etc/service
-+while : 
++while :
 +do
 +	[ -e /etc/service/mullvad-daemon/supervise/ok ] && break
 +done
 +sv up mullvad-daemon || echo "Failed to start mullvad-daemon"
- 
+
  # return 0 if version $1 is greater than or equal to $2
  function version_is_ge {

--- a/runit/preinst.patch
+++ b/runit/preinst.patch
@@ -1,9 +1,9 @@
 --- preinst	2024-07-23 15:51:35.000000000 +0100
-+++ preinst-openrc	2024-08-18 13:25:19.066673722 +0100
++++ preinst-runit	2024-08-18 13:25:19.066673722 +0100
 @@ -1,15 +1,12 @@
  #!/usr/bin/env bash
  set -eu
- 
+
 -if which systemctl &> /dev/null && systemctl is-system-running | grep -vq offline &> /dev/null; then
 -    if systemctl status mullvad-daemon &> /dev/null; then
 -        /opt/Mullvad\ VPN/resources/mullvad-setup prepare-restart || true
@@ -16,9 +16,9 @@
 +if sv status mullvad-daemon &> /dev/null; then
 +    /opt/Mullvad\ VPN/resources/mullvad-setup prepare-restart || true
 +    sv down mullvad-daemon
-+    rm -f /etc/service/mullvad-daemon /etc/service/mullvad/early-boot-blocking
++    rm -f /etc/service/mullvad-daemon
 +    cp /var/log/mullvad-vpn/daemon.log /var/log/mullvad-vpn/old-install-daemon.log \
 +        || echo "Failed to copy old daemon log"
  fi
- 
+
  # This can be removed when 2022.4 is unsupported. That version is the last version where

--- a/runit/prerm.patch
+++ b/runit/prerm.patch
@@ -1,17 +1,17 @@
 --- prerm	2022-10-14 11:36:49.000000000 +0100
-+++ /home/tfm/mullvad-repack/prerm	2022-11-13 11:34:53.472140703 +0000
++++ prerm-runit	2022-11-13 11:34:53.472140703 +0000
 @@ -21,10 +21,10 @@
  fi
- 
+
  # the user might've disabled or stopped the service themselves already
 -systemctl stop mullvad-daemon.service || true
 -systemctl disable mullvad-daemon.service || true
 -systemctl stop mullvad-early-boot-blocking.service || true
 -systemctl disable mullvad-early-boot-blocking.service || true
 +sv down mullvad-daemon || true
-+sv down mullvad-early-boot-blocking || true
-+rm -f /etc/service/mullvad-daemon /etc/service/mullvad-early-boot-blocking
-+rm -r /etc/sv/mullvad-daemon /etc/sv/mullvad-early-boot-blocking
- 
++rm -f /etc/service/mullvad-daemon
++rm -r /etc/sv/mullvad-daemon
++rm -f /etc/cron.d/mullvad-early-boot-blocking
+
  /opt/Mullvad\ VPN/resources/mullvad-setup reset-firewall || echo "Failed to reset firewall"
  /opt/Mullvad\ VPN/resources/mullvad-setup remove-device || echo "Failed to remove device from account"

--- a/sysvinit/postinst.patch
+++ b/sysvinit/postinst.patch
@@ -10,5 +10,5 @@
 +update-rc.d mullvad-daemon defaults
 +service mullvad-daemon start || echo "Failed to start mullvad-daemon"
 
-# Check if the system supports a new-enough AppArmor version.
-function supported_apparmor() {
+ # return 0 if version $1 is greater than or equal to $2
+ function version_is_ge {

--- a/sysvinit/postinst.patch
+++ b/sysvinit/postinst.patch
@@ -1,15 +1,14 @@
 --- postinst	2024-08-18 11:51:43.596999869 +0100
 +++ postinst-sysv	2024-08-18 11:51:38.224955079 +0100
-@@ -3,9 +3,9 @@
- 
+@@ -3,9 +3,8 @@
+
  chmod u+s "/usr/bin/mullvad-exclude"
- 
+
 -systemctl enable "/usr/lib/systemd/system/mullvad-daemon.service"
 -systemctl start mullvad-daemon.service || echo "Failed to start mullvad-daemon.service"
 -systemctl enable "/usr/lib/systemd/system/mullvad-early-boot-blocking.service"
 +update-rc.d mullvad-daemon defaults
 +service mullvad-daemon start || echo "Failed to start mullvad-daemon"
-+update-rc.d mullvad-early-boot-blocking defaults
- 
- # return 0 if version $1 is greater than or equal to $2
- function version_is_ge {
+
+# Check if the system supports a new-enough AppArmor version.
+function supported_apparmor() {

--- a/sysvinit/preinst.patch
+++ b/sysvinit/preinst.patch
@@ -1,6 +1,6 @@
 --- preinst	2024-07-23 15:51:35.000000000 +0100
 +++ preinst-sysv	2024-08-18 11:56:01.489150086 +0100
-@@ -1,15 +1,13 @@
+@@ -1,15 +1,12 @@
  #!/usr/bin/env bash
  set -eu
 
@@ -17,7 +17,6 @@
 +    /opt/Mullvad\ VPN/resources/mullvad-setup prepare-restart || true
 +    service mullvad-daemon stop
 +    update-rc.d mullvad-daemon disable
-+    update-rc.d mullvad-early-boot-blocking disable || true
 +    cp /var/log/mullvad-vpn/daemon.log /var/log/mullvad-vpn/old-install-daemon.log \
 +        || echo "Failed to copy old daemon log"
  fi

--- a/sysvinit/prerm.patch
+++ b/sysvinit/prerm.patch
@@ -1,8 +1,8 @@
 --- prerm	2022-10-14 11:36:49.000000000 +0100
-+++ /home/tfm/mullvad-repack/prerm	2022-11-13 11:34:53.472140703 +0000
-@@ -21,10 +21,10 @@
++++ prerm-sysv	2022-11-13 11:34:53.472140703 +0000
+@@ -21,10 +21,9 @@
  fi
- 
+
  # the user might've disabled or stopped the service themselves already
 -systemctl stop mullvad-daemon.service || true
 -systemctl disable mullvad-daemon.service || true
@@ -10,8 +10,7 @@
 -systemctl disable mullvad-early-boot-blocking.service || true
 +service mullvad-daemon stop || true
 +update-rc.d mullvad-daemon disable || true
-+service mullvad-early-boot-blocking stop || true
-+update-rc.d mullvad-early-boot-blocking disable || true
- 
++rm -f /etc/cron.d/mullvad-early-boot-blocking
+
  /opt/Mullvad\ VPN/resources/mullvad-setup reset-firewall || echo "Failed to reset firewall"
  /opt/Mullvad\ VPN/resources/mullvad-setup remove-device || echo "Failed to remove device from account"


### PR DESCRIPTION
This script used to implement an early-boot-blocking service but this was changed to a cron job that runs at reboot. I had updated this for runit, but not for the other two init systems.